### PR TITLE
Feat/league stats - count of teams, best_offense, worst_offense

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -120,5 +120,6 @@ class StatTracker
 
   def count_of_teams
     @teams.count
+
   end
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -140,4 +140,23 @@ class StatTracker
     best_offense = teams_goals_average.find { |team, avg| avg == teams_goals_average.values.max}
     best_offense.first
   end
+
+  def worst_offense
+    teams_goals_average = {}
+    @teams.each do |team|
+      total_games = 0
+      total_goals = 0
+      games = @game_teams.each do |game_team| 
+        if game_team.team_id == team.team_id
+          total_games +=1
+          total_goals += game_team.goals
+        end
+      end
+      if total_games > 0 && total_goals
+      teams_goals_average["#{team.name}"] = (total_goals.to_f / total_games.to_f)
+      end
+    end
+    worst_offense = teams_goals_average.find { |team, avg| avg == teams_goals_average.values.min}
+    worst_offense.first
+  end
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -34,92 +34,110 @@ class StatTracker
 
   def percentage_home_wins
     hash = Hash.new{ |hash, key| hash[key] = [] }
-    @total_games = 0
+    total_games = 0
     @game_teams.each do |game|
-      @total_games += 0.50
-      @key = game.game_id
-      @value_array = []
-      @value1 = game.result
-      @value2 = game.hoa
-      @value_array << @value1
-      @value_array << @value2
-      hash[@key] = @value_array
+      total_games += 0.50
+      key = game.game_id
+      value_array = []
+      value1 = game.result
+      value2 = game.hoa
+      value_array << value1
+      value_array << value2
+      hash[key] = value_array
     end
-    @home_win = 0.00
+    home_win = 0.00
     hash.values.each do |hashy|
       if hashy[0] == "WIN" && hashy[1] == "home"
-        @home_win += 1.00
+        home_win += 1.00
       end
     end
-    x = @home_win / @total_games
+    x = home_win / total_games
     (x * 100).round(2)
   end
 
   def percentage_visitor_wins
     hash = Hash.new{ |hash, key| hash[key] = [] }
-    @total_games = 0
+    total_games = 0
     @game_teams.each do |game|
-      @total_games += 0.50
-      @key = game.game_id
-      @value_array = []
-      @value1 = game.result
-      @value2 = game.hoa
-      @value_array << @value1
-      @value_array << @value2
-      hash[@key] = @value_array
+      total_games += 0.50
+      key = game.game_id
+      value_array = []
+      value1 = game.result
+      value2 = game.hoa
+      value_array << value1
+      value_array << value2
+      hash[key] = value_array
     end
-    @visitor_win = 0.00
+    visitor_win = 0.00
     hash.values.each do |hashy|
       if hashy[0] == "LOSS" && hashy[1] == "home"
-        @visitor_win += 1.00
+        visitor_win += 1.00
       end
     end
-    x = @visitor_win / @total_games
+    x = visitor_win / total_games
     (x * 100).round(2)
   end
 
   def percentage_ties
     hash = Hash.new{ |hash, key| hash[key] = [] }
-    @total_games = 0
+    total_games = 0
     @game_teams.each do |game|
-      @total_games += 0.50
-      @key = game.game_id
-      @value_array = []
-      @value1 = game.result
-      @value2 = game.hoa
-      @value_array << @value1
-      @value_array << @value2
-      hash[@key] = @value_array
+      total_games += 0.50
+      key = game.game_id
+      value_array = []
+      value1 = game.result
+      value2 = game.hoa
+      value_array << value1
+      value_array << value2
+      hash[key] = value_array
     end
-    @tie = 0.00
+    tie = 0.00
     hash.values.each do |hashy|
       if hashy[0] == "TIE" && hashy[1] == "home"
-        @tie += 1.00
+        tie += 1.00
       end
     end
-    x = @tie / @total_games
+    x = tie / total_games
     (x * 100).round(2)
   end
 
   def average_goals_by_season
     hash = Hash.new{ |hash, key| hash[key] = 0.00 }
-    @total_goals = 0.00
-    @total_games = 0.00
+    total_goals = 0.00
+    total_games = 0.00
     @games.each do |game|
-      @key = game.season
-      @value1 = game.away_goals
-      @value2 = game.home_goals
-      @total_games += 1.00
-      @total_goals += @value1
-      @total_goals += @value2
-      @avg_goals_game = (@total_goals / @total_games)
-      hash[@key] = @avg_goals_game
+      key = game.season
+      value1 = game.away_goals
+      value2 = game.home_goals
+      total_games += 1.00
+      total_goals += value1
+      total_goals += value2
+      avg_goals_game = (total_goals / total_games)
+      hash[key] = avg_goals_game
     end
     hash
   end
 
   def count_of_teams
     @teams.count
+  end
 
+  def best_offense
+    teams_goals_average = {}
+    @teams.each do |team|
+      total_games = 0
+      total_goals = 0
+      games = @game_teams.each do |game_team| 
+        if game_team.team_id == team.team_id
+          total_games +=1
+          total_goals += game_team.goals
+        end
+      end
+      if total_games > 0 && total_goals
+      teams_goals_average["#{team.name}"] = (total_goals.to_f / total_games.to_f)
+      end
+    end
+    best_offense = teams_goals_average.find { |team, avg| avg == teams_goals_average.values.max}
+    best_offense.first
   end
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -3,7 +3,6 @@ class StatTracker
   attr_reader :teams,
               :games,
               :game_teams
-
   def initialize(content)
     @teams = content[:teams]
     @games = content[:games]
@@ -118,13 +117,8 @@ class StatTracker
     end
     hash
   end
-  # original from_csv left for reference
-  # def self.from_csv(locations)
-  #   content = {}
-  #   content[:teams] = CSV.readlines(locations[:teams], headers: true, header_converters: :symbol),
-  #   content[:games] = CSV.readlines(locations[:games], headers: true, header_converters: :symbol),
-  #   content[:game_teams] = CSV.readlines(locations[:game_teams], headers: true, header_converters: :symbol)
-  #   StatTracker.new(content)
-  ## in pry you can then do stat_tracker[:team_id] and it will print stuff
-  # end
+
+  def count_of_teams
+    @teams.count
+  end
 end

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -6,8 +6,8 @@ class Team
               :stadium,
               :link
   def initialize(team_info)
-    @team_id = team_info[:team_id]
-    @franchise_id = team_info[:franchiseid]
+    @team_id = team_info[:team_id].to_i
+    @franchise_id = team_info[:franchiseid].to_i
     @name = team_info[:teamname]
     @abbreviation = team_info[:abbreviation]
     @stadium = team_info[:stadium]

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe StatTracker do
     xdescribe '#count_of_teams' do 
       it 'will return an integer with the total number of teams in the data' do
         expect(stat_tracker.count_of_teams).to be_a(Integer)
-        expect(stat_tracker.count_of_teams).to eq()
+        expect(stat_tracker.count_of_teams).to eq(32)
       end
     end
     xdescribe '#best_offense' do 

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -84,10 +84,10 @@ RSpec.describe StatTracker do
         expect(stat_tracker.count_of_teams).to eq(32)
       end
     end
-    xdescribe '#best_offense' do 
+    describe '#best_offense' do 
       it 'will return a string with the name of the team with the highest average number of goals scored per game across all seasons' do
-        expect(stat_tracker.count_of_teams).to be_a(String)
-        expect(stat_tracker.count_of_teams).to eq()
+        expect(stat_tracker.best_offense).to be_a(String)
+        expect(stat_tracker.best_offense).to eq("New York City FC")
       end
     end
     xdescribe '#worst_offense' do 

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -90,10 +90,10 @@ RSpec.describe StatTracker do
         expect(stat_tracker.best_offense).to eq("New York City FC")
       end
     end
-    xdescribe '#worst_offense' do 
+    describe '#worst_offense' do 
       it 'will return a string with the name of the team with the lowest average number of goals scored per game across all seasons' do
-        expect(stat_tracker.count_of_teams).to be_a(String)
-        expect(stat_tracker.count_of_teams).to eq()
+        # expect(stat_tracker.worst_offense).to be_a(String)
+        expect(stat_tracker.worst_offense).to eq("Houston Dynamo")
       end
     end
     xdescribe '#highest_scoring_visitor' do 


### PR DESCRIPTION
Add the following league statistics methods to StatTracker
# count_of_teams return the total number of teams in the data as an integer.
#best_offense return the  name of the team with the highest average number of goals scored per game across all seasons as a string.
#worst_offense return the name of the team with the lowest average number of goals scored per game across all seasons as a string.

